### PR TITLE
Fix: normalize chokidar paths for hot reload on Windows

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -151,16 +151,19 @@ async function startWatching(
   const changes: ChangeEvent[] = []
   watcher
     .on("add", (fp) => {
+      fp = toPosixPath(fp)
       if (buildData.ignored(fp)) return
       changes.push({ path: fp as FilePath, type: "add" })
       void rebuild(changes, clientRefresh, buildData)
     })
     .on("change", (fp) => {
+      fp = toPosixPath(fp)
       if (buildData.ignored(fp)) return
       changes.push({ path: fp as FilePath, type: "change" })
       void rebuild(changes, clientRefresh, buildData)
     })
     .on("unlink", (fp) => {
+      fp = toPosixPath(fp)
       if (buildData.ignored(fp)) return
       changes.push({ path: fp as FilePath, type: "delete" })
       void rebuild(changes, clientRefresh, buildData)


### PR DESCRIPTION
### Summary
Hot reload was not updating content when editing Markdown files inside subfolders on **Windows**.  
At root level, hot reload worked fine.

### Root Cause
The issue was caused by **inconsistent path separators** (`\` vs `/`) coming from `chokidar` on Windows.  
This made the watcher fail to properly detect file changes in subfolders.

### Fix
This patch normalizes paths with `toPosixPath(fp)` inside the `watcher` callbacks (`add`, `change`, `unlink`) before passing them to the rebuild process.  

### Testing
- Verified on **Windows 11**: hot reload now works for both root-level and nested Markdown files.  
- Verified on **Ubuntu**: no regressions introduced.  

---

Closes #2071

